### PR TITLE
update Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:5-slim
 MAINTAINER kyung yeol kim <kykim@riiid.co>
 
 WORKDIR /src/riiidbot/
-ADD . /src/riiidbot/
+ADD ./package.json /src/riiidbot/package.json
 RUN npm install
+ADD . /src/riiidbot/
 
 ENTRYPOINT ["npm"]
 CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:0.12.6-slim
+FROM node:5-slim
 MAINTAINER kyung yeol kim <kykim@riiid.co>
 
-WORKDIR /src/hubot/
-ADD . /src/hubot/
+WORKDIR /src/riiidbot/
+ADD . /src/riiidbot/
 RUN npm install
 
-ENTRYPOINT ["/src/hubot/bin/hubot", "-a", "slack"]
+ENTRYPOINT ["npm"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you don't like `docker` (:feelsgood:),
 
     $ git clone riiid/riiidbot
     $ cd riiidbot
-    $ bin/hubot
+    $ npm run start-dev
     Hubot> hubot help
 
 ## Scripting

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hubot for `riiid`.
       -e HUBOT_SLACK_TOKEN=<YOUR_SLACK_TOKEN> \
       -e FIREBASE_URL=<FIREBASE_URL> \
       -e FIREBASE_SECRET=<FIREBASE_SECRET> \
-      -e EXPRESS_PORT=<PORT_FOR_HUBOT>
+      -e EXPRESS_PORT=<PORT_FOR_HUBOT> \
       riiid/riiidbot
 
 Override `entrypoint` to test it locally.
@@ -30,3 +30,25 @@ If you don't like `docker` (:feelsgood:),
 ## Scripting
 
 See `scripts/example.coffee`, or visit [Scripting Guide](https://github.com/github/hubot/blob/master/docs/scripting.md).
+
+## Deploy
+
+### Build Image
+
+To build docker image for `riiidbot`,
+
+    $ docker build -t riiid/riiidbot .
+
+### Test Image on local
+
+    $ docker run -it --rm riiid/riiidbot run start-dev
+
+or If you with test with full env variables,
+
+    $ docker run -it --rm \
+      -p <HOST_PORT>:<PORT_FOR_HUBOT> \
+      -e HUBOT_SLACK_TOKEN=<YOUR_SLACK_TOKEN> \
+      -e FIREBASE_URL=<FIREBASE_URL> \
+      -e FIREBASE_SECRET=<FIREBASE_SECRET> \
+      -e EXPRESS_PORT=<PORT_FOR_HUBOT> \
+      riiid/riiidbot

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "author": "jwheo@riiid.co",
   "description": "A helpful robot for Riiid!",
+  "scripts": {
+    "start": "bin/hubot -a slack",
+    "start-dev": "bin/hubot"
+  },
   "dependencies": {
     "hubot": "^2.11.0",
     "hubot-calculator": "^0.4.0",


### PR DESCRIPTION
이 풀리퀘는 뭐가 좋은 건가요?
- 기존 `Dockerfile`의 `ENTRYPOINT` 를 `npm` 으로 변경하고, 실행 옵션은 `CMD` 커맨드에 설정
  - 기존의 `Dockerfile` 은 실행옵션을 오버라이드 할 수 없기 때문에 컨테이너를 로컬에서만 테스트가 불가능했음
  - 이제 아래와 같이 컨테이너를 실행하는 시점에 `CMD` 옵션을 `run start-dev` 로 오버라이드 해서 실행할 수 있음 :sunglasses: 

```
$ docker run -it --rm riiid/riiidbot run start-dev
```
- 봇이 자꾸 죽어서 노드 프로세스 관리 도구를 사용하도록 테스트 해볼 예정인데, 그때마다 `ENTRYPOINT` 를 수정할 필요가 없음 (`docker build` 를 매번 안해도 됨 :dancers: )
